### PR TITLE
Switch from procedural to functional calling style, using returns.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,12 @@ if( MPFR_FOUND AND GMP_FOUND)
     add_definitions(-DHAVE_MPFR)
 endif( MPFR_FOUND AND GMP_FOUND)
 
+
 #-----------------------------------------------------------------------
 # build configuration
 #-----------------------------------------------------------------------
 set(CMAKE_BUILD_TYPE Release)
-add_definitions(-std=c++11 -Wall)
+add_definitions(-std=c++17 -Wall)
 
 #-----------------------------------------------------------------------
 # common include directories

--- a/include/firpm/band.h
+++ b/include/firpm/band.h
@@ -59,23 +59,12 @@ namespace pm {
         std::vector<T> part;    /**< partition points (if any) inside the band */
     };
 
-    /**
-     * Gives the direction in which the change of variable is performed
-     */
-    enum convdir_t {
-        FROMFREQ,               /**< apply the change of variable \f$y=\cos(x)\f$*/
-        TOFREQ                  /**< apply the change of variable \f$y=\arccos(x)\f$*/
-    };
-
     /*! Performs the change of variable on the set of bands of interest
     * @param[in]  in input frequency bands
-    * @param[in]  direction the direction in which the change of
-    * variable is performed
     * @return output frequency bands
     */
     template<typename T>
-    std::vector<band_t<T>> bandconv(std::vector<band_t<T>> const &in,
-            convdir_t direction);
+    std::vector<band_t<T>> bandconv(std::vector<band_t<T>> const &in);
 
 } // namespace pm
 

--- a/include/firpm/band.h
+++ b/include/firpm/band.h
@@ -68,13 +68,13 @@ namespace pm {
     };
 
     /*! Performs the change of variable on the set of bands of interest
-    * @param[out] out output frequency bands
     * @param[in]  in input frequency bands
     * @param[in]  direction the direction in which the change of
     * variable is performed
+    * @return output frequency bands
     */
     template<typename T>
-    void bandconv(std::vector<band_t<T>>& out, std::vector<band_t<T>>& in,
+    std::vector<band_t<T>> bandconv(std::vector<band_t<T>> const &in,
             convdir_t direction);
 
 } // namespace pm

--- a/include/firpm/barycentric.h
+++ b/include/firpm/barycentric.h
@@ -36,90 +36,90 @@ namespace pm {
         * the evaluation of the barycentric interpolation
         * formulas (see [Berrut&Trefethen2004] and [Pachon&Trefethen2009]
         * for the implementation ideas)
-        * @param[out] w the computed weights
         * @param[in] x the interpolation points
+        * @return the computed weights
         */
         template<typename T>
-        void baryweights(std::vector<T>& w,
-                std::vector<T>& x);
+        std::vector<T> baryweights(std::vector<T> const& x);
 
         /*! Determines the current reference error according to the
         * barycentric formula (internally it also computes the barycentric weights)
-        * @param[out] delta the value of the current reference error
         * @param[in] x the current reference set (i.e., interpolation points)
         * @param[in] bands information relating to the ideal frequency response of
         * the filter
+        * @return delta the value of the current reference error
         */
         template<typename T>
-        void compdelta(T& delta, std::vector<T>& x,
-                std::vector<band_t<T>>& bands);
+        T compdelta(std::vector<T>& x,
+                std::vector<band_t<T>> const& bands);
 
         /*! Determines the current reference error according to the
         * barycentric formula
-        * @param[out] delta the value of the current reference error
         * @param[in] w the barycentric weights associated with the current reference
         * set
         * @param[in] x the current reference set (i.e. interpolation points)
         * @param[in] bands information relating to the ideal frequency response of
         * the filter
+        * @return the value of the current reference error
         */
 
         template<typename T>
-        void compdelta(T& delta, std::vector<T>& w,
-                std::vector<T>& x, std::vector<band_t<T>>& bands);
+        T compdelta(std::vector<T>& w,
+                std::vector<T>& x, std::vector<band_t<T>> const& bands);
 
         /*! Computes the filter response at the current reference set
-        * @param[out] C the vector of frequency responses at the reference set
         * @param[in] delta the current reference error
         * @param[in] x the current reference vector
         * @param[in] bands frequency band information for the ideal filter
+        * @return the vector of frequency responses at the reference set
         */
         template<typename T>
-        void compc(std::vector<T>& C, T& delta,
-                std::vector<T>& x, std::vector<band_t<T>>& bands);
+        std::vector<T> compc(T& delta,
+                std::vector<T>& x, std::vector<band_t<T>> const& bands);
 
         /*! Computes the frequency response of the current filter
-        * @param[out] Pc the frequency response amplitude value at the current node
         * @param[in] xVal the current frequency node where we do our computation
         * (the point is given in the \f$\left[-1,1\right]\f$ interval,
         * and not the initial \f$\left[0,\pi\right]\f$)
         * @param[in] x the current reference set
         * @param[in] C the frequency responses at the current reference set
         * @param[in] w the current barycentric weights
+        * @return the frequency response amplitude value at the current node
         */
         template<typename T>
-        void approx(T& Pc, T const& xVal,
-                std::vector<T>& x, std::vector<T>& C,
-                std::vector<T>& w);
+        T approx(T const& xVal,
+                std::vector<T> const& x,
+                std::vector<T> const& C,
+                std::vector<T> const& w);
 
         /*! Computes the approximation error at a given node using the current set of
         * reference points
-        * @param[out] error the requested error value
         * @param[in] xVal the current frequency node where we do our computation
         * @param[in] delta the current reference error
         * @param[in] x the current reference set
         * @param[in] C the frequency response values at the x nodes
         * @param[in] w the barycentric weights
         * @param[in] bands frequency band information for the ideal filter
+        * @return error the requested error value
         */
         template<typename T>
-        void comperror(T& error, T const& xVal,
-                T& delta, std::vector<T>& x,
-                std::vector<T>& C, std::vector<T>& w,
-                std::vector<band_t<T>>& bands);
+        T comperror(T const& xVal,
+                T& delta,
+                std::vector<T> const& x,
+                std::vector<T> const& C,
+                std::vector<T> const& w,
+                std::vector<band_t<T>> const& bands);
 
         /*! The ideal frequency response and weight information at the given frequency
         * node (it can be in the \f$\left[-1,1\right]\f$ interval,
         * and not the initial \f$\left[0,\pi\right]\f$, the difference is made with
         * information from the bands parameter)
-        * @param[out] D ideal frequency response
-        * @param[out] W weight value for the current point
         * @param[in] xVal the current frequency node where we do our computation
         * @param[in] bands frequency band information for the ideal filter
+        * @return a (D, W) tuple containing ideal frequency response and weight
         */
         template<typename T>
-        void idealvals(T& D, T& W,
-                T const& xVal, std::vector<band_t<T>>& bands);
+        std::pair<T, T> idealvals(T const& xVal, std::vector<band_t<T>>& bands);
 
 } // namespace pm
 

--- a/include/firpm/cheby.h
+++ b/include/firpm/cheby.h
@@ -52,7 +52,7 @@ namespace pm {
         * @return the vector of elements after the change of variable
         */
         template<typename T>
-        std::vector<T> chgvar(std::vector<T> const& in, T& a, T& b);
+        std::vector<T> chgvar(std::vector<T> const& in, T const& a, T const& b);
 
         /*! Function that generates equidistant nodes inside the
         * \f$\left[0,\pi\right]\f$ interval, meaning values of the

--- a/include/firpm/cheby.h
+++ b/include/firpm/cheby.h
@@ -82,7 +82,7 @@ namespace pm {
         *  @return the vector of coefficients of the derivative of the CI
         */
         template<typename T>
-        std::vector<T> diffcoeffs(std::vector<T>& c,
+        std::vector<T> diffcoeffs(std::vector<T> const& c,
                         chebkind_t kind = SECOND);
 
         /*! Chebyshev proxy rootfinding method for a given CI

--- a/include/firpm/cheby.h
+++ b/include/firpm/cheby.h
@@ -39,60 +39,53 @@ namespace pm {
 
         /*! Computes the cosines of the elements of a vector
         * @param[in] in the vector to process
-        * @param[out] out the vector containing the cosines of the elements from the
-        * vector in
+        * @return the vector containing the cosines of the elements from the vector in
         */
         template<typename T>
-        void cos(std::vector<T>& out,
-                std::vector<T> const& in);
+        std::vector<T> cos(std::vector<T> const &in);
 
         /*! Does a change of variable from the interval \f$\left[-1, 1\right]\f$ to the
         * interval \f$\left[a, b\right]\f$ on the elements of a given input vector
         * @param[in] in the vector of elements in \f$\left[-1, 1\right]\f$
-        * @param[out] out the vector of elements after the change of variable
         * @param[in] a left bound of the desired interval
         * @param[in] b right bound of the desired interval
+        * @return the vector of elements after the change of variable
         */
         template<typename T>
-        void chgvar(std::vector<T>& out,
-                std::vector<T> const& in,
-                T& a, T& b);
+        std::vector<T> chgvar(std::vector<T> const& in, T& a, T& b);
 
         /*! Function that generates equidistant nodes inside the
         * \f$\left[0,\pi\right]\f$ interval, meaning values of the
         * form \f$\frac{i\pi}{n-1}\f$, where \f$0\leq i\leq n-1\f$
-        * @param[out] v the vector that will contain the equi-distributed points
         * @param[in] n the number of points which will be computed
+        * @return the vector that will contain the equi-distributed points
         */
         template<typename T>
-        void equipts(std::vector<T>& v, std::size_t n);
+        std::vector<T> equipts(std::size_t n);
 
 
         /*! This function computes the values of the coefficients of the CI when
         * Chebyshev nodes of the second kind are used
-        * @param[out] c vector used to hold the values of the computed coefficients
         * @param[in] fv vector that holds the value of the current function to
         * approximate at the Chebyshev nodes of the second kind scaled to the
         * appropriate interval (in our case it will be \f$\left[0,\pi\right]\f$)
+        * @return vector used to hold the values of the computed coefficients
         */
         template<typename T>
-        void chebcoeffs(std::vector<T>& c,
-                        std::vector<T>& fv);
+        std::vector<T> chebcoeffs(std::vector<T>& fv);
 
         /*! Function that generates the coefficients of the derivative of a given CI
-        *  @param[out] dc the vector of coefficients of the derivative of the CI
         *  @param[in] c the vector of coefficients of the CI whose derivative we
         *  want to compute
         *  @param[in] kind what kind of coefficient do we want to compute (for a
         *  Chebyshev expansion of the first or second kind)
+        *  @return the vector of coefficients of the derivative of the CI
         */
         template<typename T>
-        void diffcoeffs(std::vector<T>& dc,
-                        std::vector<T>& c,
+        std::vector<T> diffcoeffs(std::vector<T>& c,
                         chebkind_t kind = SECOND);
 
         /*! Chebyshev proxy rootfinding method for a given CI
-        * @param[out] r the vector of computed roots of the CI
         * @param[in] c the Chebyshev coeffients of the polynomial whose roots
         * we want to find
         * @param[in] dom the real domain where we are looking for the roots
@@ -101,9 +94,10 @@ namespace pm {
         * the vein of [Parlett&Reinsch1969] "Balancing a Matrix for
         * Calculation of Eigenvalues and Eigenvectors") for the resulting
         * Chebyshev companion matrix
+        * @return the vector of computed roots of the CI
         */
         template<typename T>
-        void roots(std::vector<T>& r, std::vector<T>& c,
+        std::vector<T> roots(std::vector<T>& c,
                 std::pair<T, T> const& dom,
                 chebkind_t kind = SECOND,
                 bool balance = true);

--- a/include/firpm/pm.h
+++ b/include/firpm/pm.h
@@ -127,8 +127,8 @@ namespace pm {
     void refscaling(status_t& status,
             std::vector<T>& nx, std::vector<band_t<T>>& ncbands,
             std::vector<band_t<T>>& nfbands, std::size_t nxs,
-            std::vector<T>& x, std::vector<band_t<T>>& cbands,
-            std::vector<band_t<T>>& fbands);
+            std::vector<T>& x, std::vector<band_t<T>> const& cbands,
+            std::vector<band_t<T>> const& fbands);
 
     /*! An internal routine which implements the exchange algorithm for designing 
     * FIR filters

--- a/include/firpm/pm.h
+++ b/include/firpm/pm.h
@@ -93,15 +93,14 @@ namespace pm {
 
     /*! An implementation of the uniform initialization approach for
     * starting the Parks-McClellan algorithm
-    * @param[out] omega the initial set of references to be computed
     * @param[in] B the frequency bands of interest (i.e., stopbands and
     * passbands for example)
     * @param[in] n the size of the reference set
+    * @return the initial set of references to be computed
     */
 
     template<typename T>
-    void uniform(std::vector<T>& omega,
-            std::vector<band_t<T>>& B, std::size_t n);
+    std::vector<T> uniform(std::vector<band_t<T>>& B, std::size_t n);
 
     /*! An implementation of the reference scaling approach mentioned
     * in section 4 of the article.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ set(PROJECT_NAME_STR firpmlib-build)
 project(${PROJECT_NAME_STR})
 
 set(CMAKE_BUILD_TYPE Release)
-add_definitions("-std=c++11")
+add_definitions("-std=c++17")
 
 file(GLOB PROJECT_SRC_FILES ${PROJECT_SOURCE_DIR}/*.cpp)
 set(PROJECT_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/../include/)

--- a/src/band.cpp
+++ b/src/band.cpp
@@ -20,10 +20,10 @@
 namespace pm {
 
     template<typename T>
-    void bandconv(std::vector<band_t<T>>& out, std::vector<band_t<T>>& in,
+    std::vector<band_t<T>> bandconv(std::vector<band_t<T>>& in,
             convdir_t direction)
     {
-        out.resize(in.size());
+        std::vector<band_t<T>> out(in.size());
         std::size_t n = in.size() - 1u;
         for (std::size_t i{0u}; i < in.size(); ++i)
         {
@@ -48,22 +48,20 @@ namespace pm {
                 std::sort(begin(out[i].part), end(out[i].part));
             }
         }
+        return out;
     }
 
     /* Template instantiation */
-    template void bandconv<double>(
-        std::vector<band_t<double>>& out,
+    template std::vector<band_t<double>> bandconv<double>(
         std::vector<band_t<double>>& in,
             convdir_t direction);
 
-    template void bandconv<long double>(
-        std::vector<band_t<long double>>& out,
+    template std::vector<band_t<long double>> bandconv<long double>(
         std::vector<band_t<long double>>& in,
             convdir_t direction);
 
 #ifdef HAVE_MPFR
-    template void bandconv<mpfr::mpreal>(
-        std::vector<band_t<mpfr::mpreal>>& out,
+    template std::vector<band_t<mpfr::mpreal>> bandconv<mpfr::mpreal>(
         std::vector<band_t<mpfr::mpreal>>& in,
             convdir_t direction);
 #endif

--- a/src/band.cpp
+++ b/src/band.cpp
@@ -20,7 +20,7 @@
 namespace pm {
 
     template<typename T>
-    std::vector<band_t<T>> bandconv(std::vector<band_t<T>>& in,
+    std::vector<band_t<T>> bandconv(std::vector<band_t<T>> const &in,
             convdir_t direction)
     {
         std::vector<band_t<T>> out(in.size());
@@ -53,16 +53,16 @@ namespace pm {
 
     /* Template instantiation */
     template std::vector<band_t<double>> bandconv<double>(
-        std::vector<band_t<double>>& in,
+        std::vector<band_t<double>> const &in,
             convdir_t direction);
 
     template std::vector<band_t<long double>> bandconv<long double>(
-        std::vector<band_t<long double>>& in,
+        std::vector<band_t<long double>> const &in,
             convdir_t direction);
 
 #ifdef HAVE_MPFR
     template std::vector<band_t<mpfr::mpreal>> bandconv<mpfr::mpreal>(
-        std::vector<band_t<mpfr::mpreal>>& in,
+        std::vector<band_t<mpfr::mpreal>> const &in,
             convdir_t direction);
 #endif
 

--- a/src/band.cpp
+++ b/src/band.cpp
@@ -20,8 +20,7 @@
 namespace pm {
 
     template<typename T>
-    std::vector<band_t<T>> bandconv(std::vector<band_t<T>> const &in,
-            convdir_t direction)
+    std::vector<band_t<T>> bandconv(std::vector<band_t<T>> const& in)
     {
         std::vector<band_t<T>> out(in.size());
         std::size_t n = in.size() - 1u;
@@ -31,39 +30,27 @@ namespace pm {
             out[i].amplitude = in[n - i].amplitude;
             out[i].xs        = in[n - i].xs;
             out[i].part      = in[n - i].part;
-            if (direction == convdir_t::FROMFREQ)
-            {
-                out[i].start = pmmath::cos(in[n - i].stop);
-                out[i].stop  = pmmath::cos(in[n - i].start);
-                out[i].space = space_t::CHEBY;
-                for(std::size_t j{0}; j < out[i].part.size(); ++j)
-                    out[i].part[j] = pmmath::cos(out[i].part[j]);
-                std::sort(begin(out[i].part), end(out[i].part));
-            } else {
-                out[i].start = pmmath::acos(in[n - i].stop);
-                out[i].stop  = pmmath::acos(in[n - i].start);
-                out[i].space = space_t::FREQ;
-                for(std::size_t j{0}; j < out[i].part.size(); ++j)
-                    out[i].part[j] = pmmath::acos(out[i].part[j]);
-                std::sort(begin(out[i].part), end(out[i].part));
-            }
+
+            out[i].start = pmmath::cos(in[n - i].stop);
+            out[i].stop  = pmmath::cos(in[n - i].start);
+            out[i].space = space_t::CHEBY;
+            for(std::size_t j{0}; j < out[i].part.size(); ++j)
+                out[i].part[j] = pmmath::cos(out[i].part[j]);
+            std::sort(begin(out[i].part), end(out[i].part));
         }
         return out;
     }
 
     /* Template instantiation */
     template std::vector<band_t<double>> bandconv<double>(
-        std::vector<band_t<double>> const &in,
-            convdir_t direction);
+        std::vector<band_t<double>> const &in);
 
     template std::vector<band_t<long double>> bandconv<long double>(
-        std::vector<band_t<long double>> const &in,
-            convdir_t direction);
+        std::vector<band_t<long double>> const &in);
 
 #ifdef HAVE_MPFR
     template std::vector<band_t<mpfr::mpreal>> bandconv<mpfr::mpreal>(
-        std::vector<band_t<mpfr::mpreal>> const &in,
-            convdir_t direction);
+        std::vector<band_t<mpfr::mpreal>> const &in);
 #endif
 
 } // namespace pm

--- a/src/cheby.cpp
+++ b/src/cheby.cpp
@@ -131,7 +131,7 @@ namespace pm {
     }
 
     template<typename T>
-    std::vector<T> chgvar(std::vector<T> const& in, T& a, T& b)
+    std::vector<T> chgvar(std::vector<T> const& in, T const&a, T const& b)
     {
         std::vector<T> out(in.size());
 
@@ -319,7 +319,7 @@ namespace pm {
     template std::vector<double> cos<double>(std::vector<double> const &in);
 
     template std::vector<double> chgvar<double>(std::vector<double> const& in,
-            double& a, double& b);
+            double const& a, double const& b);
 
     template std::vector<double> equipts<double>(std::size_t n);
 
@@ -338,7 +338,7 @@ namespace pm {
     template std::vector<long double> cos<long double>(std::vector<long double> const &in);
 
     template std::vector<long double> chgvar<long double>(std::vector<long double> const& in,
-            long double& a, long double& b);
+            long double const& a, long double const& b);
 
     template std::vector<long double> equipts<long double>(std::size_t n);
 
@@ -356,7 +356,7 @@ namespace pm {
     template std::vector<mpfr::mpreal> cos<mpfr::mpreal>(std::vector<mpfr::mpreal> const &in);
 
     template std::vector<mpfr::mpreal> chgvar<mpfr::mpreal>(std::vector<mpfr::mpreal> const& in,
-            mpfr::mpreal& a, mpfr::mpreal& b);
+            mpfr::mpreal const& a, mpfr::mpreal const& b);
 
     template std::vector<mpfr::mpreal> equipts<mpfr::mpreal>(std::size_t n);
 

--- a/src/cheby.cpp
+++ b/src/cheby.cpp
@@ -246,7 +246,7 @@ namespace pm {
     // function that generates the coefficients of the 
     // derivative of a given CI
     template<typename T>
-    std::vector<T> diffcoeffs(std::vector<T>& c,
+    std::vector<T> diffcoeffs(std::vector<T> const& c,
                     chebkind_t kind)
     {
         std::vector<T> dc(c.size()-1);
@@ -326,7 +326,7 @@ namespace pm {
 
     template std::vector<double> chebcoeffs<double>(std::vector<double>& fv);
 
-    template std::vector<double> diffcoeffs<double>(std::vector<double>& c,
+    template std::vector<double> diffcoeffs<double>(std::vector<double> const& c,
                     chebkind_t kind);
 
     template std::vector<double> roots<double>(std::vector<double>& c,
@@ -345,7 +345,7 @@ namespace pm {
 
     template std::vector<long double> chebcoeffs<long double>(std::vector<long double>& fv);
 
-    template std::vector<long double> diffcoeffs<long double>(std::vector<long double>& c,
+    template std::vector<long double> diffcoeffs<long double>(std::vector<long double> const& c,
                     chebkind_t kind);
 
     template std::vector<long double> roots<long double>(std::vector<long double>& c,
@@ -363,7 +363,7 @@ namespace pm {
 
     template std::vector<mpfr::mpreal> chebcoeffs<mpfr::mpreal>(std::vector<mpfr::mpreal>& fv);
 
-    template std::vector<mpfr::mpreal> diffcoeffs<mpfr::mpreal>(std::vector<mpfr::mpreal>& c,
+    template std::vector<mpfr::mpreal> diffcoeffs<mpfr::mpreal>(std::vector<mpfr::mpreal> const& c,
                     chebkind_t kind);
 
     template std::vector<mpfr::mpreal> roots<mpfr::mpreal>(std::vector<mpfr::mpreal>& c,

--- a/src/cheby.cpp
+++ b/src/cheby.cpp
@@ -120,26 +120,29 @@ namespace pm {
     }
 
     template<typename T>
-    void cos(std::vector<T>& out,
-            std::vector<T> const& in)
+    std::vector<T> cos(std::vector<T> const &in)
     {
-        out.resize(in.size());
+        std::vector<T> out(in.size());
+
         for(std::size_t i{0u}; i < in.size(); ++i)
             out[i] = pmmath::cos(in[i]);
+
+        return out;
     }
 
     template<typename T>
-    void chgvar(std::vector<T>& out,
-            std::vector<T> const& in,
-            T& a, T& b)
+    std::vector<T> chgvar(std::vector<T> const& in, T& a, T& b)
     {
-        out.resize(in.size());
+        std::vector<T> out(in.size());
+
         for(std::size_t i{0u}; i < in.size(); ++i)
             out[i] = (b + a) / 2 + in[i] * (b - a) / 2;
+
+        return out;
     }
 
     template<typename T>
-    void clenshaw(T& result, const std::vector<T>& p,
+    T clenshaw(const std::vector<T>& p,
             T const& x, T const& a, T const& b)
     {
         T bn1, bn2, bn;
@@ -163,12 +166,11 @@ namespace pm {
 
         // set the value for the result
         // (i.e., the CI value at x)
-        result = bn1 - buffer * bn2;
+        return bn1 - buffer * bn2;
     }
 
     template<typename T>
-    void clenshaw(T& result,
-                std::vector<T> const& p,
+    T clenshaw(std::vector<T> const& p,
                 T const& x,
                 chebkind_t kind)
     {
@@ -186,32 +188,33 @@ namespace pm {
         }
 
         if(kind == FIRST)
-            result = x * bn1 - bn2 + p[0];
+            return x * bn1 - bn2 + p[0];
         else
-            result = (x * 2) * bn1 - bn2 + p[0];
+            return (x * 2) * bn1 - bn2 + p[0];
     }
 
     template<typename T>
-    void equipts(std::vector<T>& v, std::size_t n)
+    std::vector<T> equipts(std::size_t n)
     {
-        v.resize(n);
+        std::vector<T> v(n);
         // store the points in the vector v as 
         // v[i] = i * pi / (n-1)
         for(std::size_t i{0u}; i < n; ++i) {
             v[i] = pmmath::const_pi<T>() * i;
             v[i] /= (n-1);
         }
+
+        return v;
     }
 
     // this function computes the values of the coefficients of 
     // the CI when Chebyshev nodes of the second kind are used
     template<typename T>
-    void chebcoeffs(std::vector<T>& c,
-            std::vector<T>& fv)
+    std::vector<T> chebcoeffs(std::vector<T>& fv)
     {
         std::size_t n = fv.size();
-        std::vector<T> v(n);
-        equipts(v, n);
+        std::vector<T> c(n);
+        std::vector<T> v = equipts<T>(n);
 
         T buffer;
 
@@ -225,7 +228,7 @@ namespace pm {
             // compute the actual value at the Chebyshev
             // node cos(i * pi / n)
             buffer = pmmath::cos(v[i]);
-            clenshaw(c[i], fv, buffer, FIRST);
+            c[i] = clenshaw(fv, buffer, FIRST);
 
             if(i == 0u || i == n-1u) {
                 c[i] /= (n-1u);
@@ -237,16 +240,17 @@ namespace pm {
         fv[0] = oldValue1;
         fv[n-1u] = oldValue2;
 
+        return c;
     }
 
     // function that generates the coefficients of the 
     // derivative of a given CI
     template<typename T>
-    void diffcoeffs(std::vector<T>& dc,
-                    std::vector<T>& c,
+    std::vector<T> diffcoeffs(std::vector<T>& c,
                     chebkind_t kind)
     {
-        dc.resize(c.size()-1);
+        std::vector<T> dc(c.size()-1);
+
         switch(kind) {
             case FIRST: {
                 int n = c.size() - 2;
@@ -266,18 +270,20 @@ namespace pm {
             }
             break;
         }
+
+        return dc;
     }
 
     template<typename T>
-    void roots(std::vector<T>& r, std::vector<T>& c,
+    std::vector<T> roots(std::vector<T>& c,
             std::pair<T, T> const& dom,
             chebkind_t kind,
             bool balance)
     {
-        r.clear();
+        std::vector<T> r;
         for(auto &it : c)
             if(!pmmath::isfinite(it))
-                return;
+                return {};
 
         // preprocess c and remove all the high order
         // zero coefficients
@@ -303,75 +309,64 @@ namespace pm {
         } else if(idx == 1) {
             r.push_back(-c[0u] / c[1u]);
         }
+        return r;
     }
 
     /* Explicit instantiation */
 
     /* double precision */
 
-    template void cos<double>(std::vector<double>& out,
-            std::vector<double> const& in);
+    template std::vector<double> cos<double>(std::vector<double> const &in);
 
-    template void chgvar<double>(std::vector<double>& out,
-            std::vector<double> const& in,
+    template std::vector<double> chgvar<double>(std::vector<double> const& in,
             double& a, double& b);
 
-    template void equipts<double>(std::vector<double>& v, std::size_t n);
+    template std::vector<double> equipts<double>(std::size_t n);
 
 
-    template void chebcoeffs<double>(std::vector<double>& c,
-                    std::vector<double>& fv);
+    template std::vector<double> chebcoeffs<double>(std::vector<double>& fv);
 
-    template void diffcoeffs<double>(std::vector<double>& dc,
-                    std::vector<double>& c,
+    template std::vector<double> diffcoeffs<double>(std::vector<double>& c,
                     chebkind_t kind);
 
-    template void roots<double>(std::vector<double>& r, std::vector<double>& c,
+    template std::vector<double> roots<double>(std::vector<double>& c,
             std::pair<double, double> const& dom,
             chebkind_t kind, bool balance);
 
     /* long double precision */
 
-    template void cos<long double>(std::vector<long double>& out,
-            std::vector<long double> const& in);
+    template std::vector<long double> cos<long double>(std::vector<long double> const &in);
 
-    template void chgvar<long double>(std::vector<long double>& out,
-            std::vector<long double> const& in,
+    template std::vector<long double> chgvar<long double>(std::vector<long double> const& in,
             long double& a, long double& b);
 
-    template void equipts<long double>(std::vector<long double>& v, std::size_t n);
+    template std::vector<long double> equipts<long double>(std::size_t n);
 
 
-    template void chebcoeffs<long double>(std::vector<long double>& c,
-                    std::vector<long double>& fv);
+    template std::vector<long double> chebcoeffs<long double>(std::vector<long double>& fv);
 
-    template void diffcoeffs<long double>(std::vector<long double>& dc,
-                    std::vector<long double>& c,
+    template std::vector<long double> diffcoeffs<long double>(std::vector<long double>& c,
                     chebkind_t kind);
 
-    template void roots<long double>(std::vector<long double>& r, std::vector<long double>& c,
+    template std::vector<long double> roots<long double>(std::vector<long double>& c,
             std::pair<long double, long double> const& dom,
             chebkind_t kind, bool balance);
 
 #ifdef HAVE_MPFR
-    template void cos<mpfr::mpreal>(std::vector<mpfr::mpreal>& out,
-            std::vector<mpfr::mpreal> const& in);
+    template std::vector<mpfr::mpreal> cos<mpfr::mpreal>(std::vector<mpfr::mpreal> const &in);
 
-    template void chgvar<mpfr::mpreal>(std::vector<mpfr::mpreal>& out,
-            std::vector<mpfr::mpreal> const& in,
+    template std::vector<mpfr::mpreal> chgvar<mpfr::mpreal>(std::vector<mpfr::mpreal> const& in,
             mpfr::mpreal& a, mpfr::mpreal& b);
 
-    template void equipts<mpfr::mpreal>(std::vector<mpfr::mpreal>& v, std::size_t n);
+    template std::vector<mpfr::mpreal> equipts<mpfr::mpreal>(std::size_t n);
 
 
-    template void chebcoeffs<mpfr::mpreal>(std::vector<mpfr::mpreal>& c,
-                    std::vector<mpfr::mpreal>& fv);
+    template std::vector<mpfr::mpreal> chebcoeffs<mpfr::mpreal>(std::vector<mpfr::mpreal>& fv);
 
-    template void diffcoeffs<mpfr::mpreal>(std::vector<mpfr::mpreal>& dc,
-                    std::vector<mpfr::mpreal>& c,
+    template std::vector<mpfr::mpreal> diffcoeffs<mpfr::mpreal>(std::vector<mpfr::mpreal>& c,
                     chebkind_t kind);
 
-    template void roots<mpfr::mpreal>(std::vector<mpfr::mpreal>& r, std::vector<mpfr::mpreal>& c,
+    template std::vector<mpfr::mpreal> roots<mpfr::mpreal>(std::vector<mpfr::mpreal>& c,
             std::pair<mpfr::mpreal, mpfr::mpreal> const& dom,
             chebkind_t kind, bool balance);
 #endif

--- a/src/pm.cpp
+++ b/src/pm.cpp
@@ -779,7 +779,6 @@ namespace pm {
             parseSpecification(output.status, f, a, w);
             std::vector<T> h;
             std::vector<band_t<T>> fbands;
-            std::vector<band_t<T>> cbands;
             std::vector<std::vector<std::size_t>> bIdx;
 
             std::size_t nbands{0u};
@@ -895,7 +894,7 @@ namespace pm {
                 }
             }
 
-            bandconv(cbands, fbands, convdir_t::FROMFREQ);
+            std::vector<band_t<T>> cbands = bandconv(fbands, convdir_t::FROMFREQ);
             std::function<T(T)> wf = [&cbands](T x) -> T {
                 for(std::size_t i{0u}; i < cbands.size(); ++i)
                     if(cbands[i].start <= x && x <= cbands[i].stop)
@@ -914,7 +913,7 @@ namespace pm {
                     if (fbands.size() <= (deg + 2u) / 4) {
                         std::vector<T> omega = uniform(fbands, deg + 2u);
                         x = cos(omega);
-                        bandconv(cbands, fbands, convdir_t::FROMFREQ);
+                        cbands = bandconv(fbands, convdir_t::FROMFREQ);
                     } else {
                         // use AFP strategy for very small degrees (wrt nb of bands)
                         std::vector<T> mesh = wam(cbands, deg);
@@ -944,7 +943,7 @@ namespace pm {
                         if (fbands.size() <= (sdegs[0] + 2u) / 4) {
                             std::vector<T> omega = uniform(fbands, sdegs[0]+2u);
                             x = cos(omega);
-                            bandconv(cbands, fbands, convdir_t::FROMFREQ);
+                            cbands = bandconv(fbands, convdir_t::FROMFREQ);
                         } else {
                             // use AFP strategy for very small degrees (wrt nb of bands)
                             std::vector<T> mesh = wam(cbands, sdegs[0]);
@@ -1087,7 +1086,6 @@ namespace pm {
             parseSpecification(output.status, f, a, w);
             std::vector<T> h;
             std::vector<band_t<T>> fbands(w.size());
-            std::vector<band_t<T>> cbands;
             std::vector<T> fn{f};
             std::size_t deg = n / 2u;
             T sFactor = a[1] / (f[1] * pmmath::const_pi<T>());
@@ -1261,7 +1259,7 @@ namespace pm {
                 }
             }
 
-            bandconv(cbands, fbands, convdir_t::FROMFREQ);
+            std::vector<band_t<T>> cbands = bandconv(fbands, convdir_t::FROMFREQ);
             std::function<T(T)> wf = [&cbands](T x) -> T {
                 for(std::size_t i{0u}; i < cbands.size(); ++i)
                     if(cbands[i].start <= x && x <= cbands[i].stop)
@@ -1280,7 +1278,7 @@ namespace pm {
                     if (fbands.size() <= (deg + 2u) / 4) {
                         std::vector<T> omega = uniform(fbands, deg + 2u);
                         x = cos(omega);
-                        bandconv(cbands, fbands, convdir_t::FROMFREQ);
+                        cbands = bandconv(fbands, convdir_t::FROMFREQ);
                     } else {
                         // use AFP strategy for very small degrees (wrt nb of bands)
                         std::vector<T> mesh = wam(cbands, deg);
@@ -1310,7 +1308,7 @@ namespace pm {
                         if (fbands.size() <= (sdegs[0] + 2u) / 4) {
                             std::vector<T> omega = uniform(fbands, sdegs[0]+2u);
                             x = cos(omega);
-                            bandconv(cbands, fbands, convdir_t::FROMFREQ);
+                            cbands = bandconv(fbands, convdir_t::FROMFREQ);
                         } else {
                             // use AFP strategy for very small degrees (wrt nb of bands)
                             std::vector<T> mesh = wam(cbands, sdegs[0]);

--- a/src/pm.cpp
+++ b/src/pm.cpp
@@ -92,16 +92,14 @@ namespace pm {
     void wam(std::vector<T>& wam, std::vector<band_t<T>>& cb,
             std::size_t deg)
     {
-        std::vector<T> cp;
-        equipts(cp, deg + 2u);
-        cos(cp, cp);
+        std::vector<T> cp = equipts<T>(deg + 2u);
+        cp = cos(cp);
         std::sort(begin(cp), end(cp));
         for(std::size_t i{0u}; i < cb.size(); ++i)
         {
             if(cb[i].start != cb[i].stop)
             {
-                std::vector<T> bufferNodes;
-                chgvar(bufferNodes, cp, cb[i].start, cb[i].stop);
+                std::vector<T> bufferNodes = chgvar(cp, cb[i].start, cb[i].stop);
                 bufferNodes[0] = cb[i].start;
                 bufferNodes[bufferNodes.size()-1u] = cb[i].stop;
                 for(auto& it : bufferNodes)
@@ -334,9 +332,8 @@ namespace pm {
 
         // 3.   Use an eigenvalue solver on each subinterval to find the
         //      local extrema that are located inside the frequency bands
-        std::vector<T> chebyNodes(Nmax + 1u);
-        equipts(chebyNodes, Nmax + 1u);
-        cos(chebyNodes, chebyNodes);
+        std::vector<T> chebyNodes = equipts<T>(Nmax + 1u);
+        chebyNodes = cos(chebyNodes);
 
         std::vector<std::pair<T, T>> potentialExtrema;
         std::vector<T> pEx;
@@ -388,8 +385,7 @@ namespace pm {
                 mpfr::mpreal::set_default_prec(prec);
             #endif
             // find the Chebyshev nodes scaled to the current subinterval
-            std::vector<T> siCN(Nmax + 1u);
-            chgvar(siCN, chebyNodes, subIntervals[i].first,
+            std::vector<T> siCN = chgvar(chebyNodes, subIntervals[i].first,
                     subIntervals[i].second);
 
             // compute the Chebyshev interpolation function values on the
@@ -401,17 +397,14 @@ namespace pm {
 
             // compute the values of the CI coefficients and those of its
             // derivative
-            std::vector<T> c(Nmax + 1u);
-            chebcoeffs(c, fx);
-            std::vector<T> dc(Nmax);
-            diffcoeffs(dc, c);
+            std::vector<T> c = chebcoeffs(fx);
+            std::vector<T> dc = diffcoeffs(c);
 
             // solve the corresponding eigenvalue problem and determine the
             // local extrema situated in the current subinterval
-            std::vector<T> eigenRoots;
-            roots(eigenRoots, dc, dom);
+            std::vector<T> eigenRoots = roots(dc, dom);
             if(!eigenRoots.empty()) {
-                chgvar(eigenRoots, eigenRoots,
+                eigenRoots = chgvar(eigenRoots,
                         subIntervals[i].first, subIntervals[i].second);
                 for (std::size_t j{0u}; j < eigenRoots.size(); ++j)
                     pExs[i].push_back(eigenRoots[j]);
@@ -684,9 +677,8 @@ namespace pm {
         T finalDelta = output.delta;
         output.delta = pmmath::fabs(output.delta);
         compc(finalC, finalDelta, output.x, chebyBands);
-        std::vector<T> finalChebyNodes(degree + 1);
-        equipts(finalChebyNodes, degree + 1);
-        cos(finalChebyNodes, finalChebyNodes);
+        std::vector<T> finalChebyNodes = equipts<T>(degree + 1);
+        finalChebyNodes = cos(finalChebyNodes);
         std::vector<T> fv(degree + 1);
 
         for (std::size_t i{0u}; i < fv.size(); ++i) {
@@ -703,7 +695,7 @@ namespace pm {
             }
         }
 
-        chebcoeffs(output.h, fv);
+        output.h = chebcoeffs(fv);
 
         return output;
     }
@@ -920,7 +912,7 @@ namespace pm {
                     if (fbands.size() <= (deg + 2u) / 4) {
                         std::vector<T> omega;
                         uniform(omega, fbands, deg + 2u);
-                        cos(x, omega);
+                        x = cos(omega);
                         bandconv(cbands, fbands, convdir_t::FROMFREQ);
                     } else {
                         // use AFP strategy for very small degrees (wrt nb of bands)
@@ -952,7 +944,7 @@ namespace pm {
                         if (fbands.size() <= (sdegs[0] + 2u) / 4) {
                             std::vector<T> omega;
                             uniform(omega, fbands, sdegs[0]+2u);
-                            cos(x, omega);
+                            x = cos(omega);
                             bandconv(cbands, fbands, convdir_t::FROMFREQ);
                         } else {
                             // use AFP strategy for very small degrees (wrt nb of bands)
@@ -1295,7 +1287,7 @@ namespace pm {
                     if (fbands.size() <= (deg + 2u) / 4) {
                         std::vector<T> omega;
                         uniform(omega, fbands, deg + 2u);
-                        cos(x, omega);
+                        x = cos(omega);
                         bandconv(cbands, fbands, convdir_t::FROMFREQ);
                     } else {
                         // use AFP strategy for very small degrees (wrt nb of bands)
@@ -1327,7 +1319,7 @@ namespace pm {
                         if (fbands.size() <= (sdegs[0] + 2u) / 4) {
                             std::vector<T> omega;
                             uniform(omega, fbands, sdegs[0]+2u);
-                            cos(x, omega);
+                            x = cos(omega);
                             bandconv(cbands, fbands, convdir_t::FROMFREQ);
                         } else {
                             // use AFP strategy for very small degrees (wrt nb of bands)

--- a/src/pm.cpp
+++ b/src/pm.cpp
@@ -164,8 +164,8 @@ namespace pm {
     void refscaling(status_t& status,
             std::vector<T>& newX, std::vector<band_t<T>>& newChebyBands,
             std::vector<band_t<T>>& newFreqBands, std::size_t newXSize,
-            std::vector<T>& x, std::vector<band_t<T>>& chebyBands,
-            std::vector<band_t<T>>& freqBands)
+            std::vector<T>& x, std::vector<band_t<T>> const& chebyBands,
+            std::vector<band_t<T>> const& freqBands)
     {
         std::vector<std::size_t> newDistribution(chebyBands.size());
         for(std::size_t i{0u}; i < chebyBands.size(); ++i)
@@ -277,7 +277,7 @@ namespace pm {
     }
 
     template<typename T>
-    std::vector<std::pair<T, T>> split(std::vector<band_t<T>>& chebyBands, std::vector<T> &x) {
+    std::vector<std::pair<T, T>> split(std::vector<band_t<T>> const& chebyBands, std::vector<T> &x) {
         std::vector<std::pair<T, T>> subIntervals;
         std::vector<T> splitpts = x;
         for(std::size_t i{0u}; i < chebyBands.size(); ++i) {
@@ -1400,8 +1400,8 @@ namespace pm {
                 std::vector<band_t<double>>& newFreqBands,
                 std::size_t newXSize,
                 std::vector<double>& x,
-                std::vector<band_t<double>>& chebyBands,
-                std::vector<band_t<double>>& freqBands);
+                std::vector<band_t<double>> const& chebyBands,
+                std::vector<band_t<double>> const& freqBands);
 
     template pmoutput_t<double> exchange<double>(std::vector<double>& x,
                 std::vector<band_t<double>>& chebyBands,
@@ -1478,8 +1478,8 @@ namespace pm {
                 std::vector<band_t<long double>>& newFreqBands,
                 std::size_t newXSize,
                 std::vector<long double>& x,
-                std::vector<band_t<long double>>& chebyBands,
-                std::vector<band_t<long double>>& freqBands);
+                std::vector<band_t<long double>> const& chebyBands,
+                std::vector<band_t<long double>> const& freqBands);
 
     template pmoutput_t<long double> exchange<long double>(std::vector<long double>& x,
                 std::vector<band_t<long double>>& chebyBands,
@@ -1557,11 +1557,11 @@ namespace pm {
                 std::vector<band_t<mpfr::mpreal>>& newFreqBands,
                 std::size_t newXSize,
                 std::vector<mpfr::mpreal>& x,
-                std::vector<band_t<mpfr::mpreal>>& chebyBands,
-                std::vector<band_t<mpfr::mpreal>>& freqBands);
+                std::vector<band_t<mpfr::mpreal>> const& chebyBands,
+                std::vector<band_t<mpfr::mpreal>> const& freqBands);
 
     template pmoutput_t<mpfr::mpreal> exchange<mpfr::mpreal>(std::vector<mpfr::mpreal>& x,
-                std::vector<band_t<mpfr::mpreal>>& chebyBands,
+                std::vector<band_t<mpfr::mpreal>>&chebyBands,
                 double eps,
                 std::size_t nmax, unsigned long prec);
 

--- a/src/pm.cpp
+++ b/src/pm.cpp
@@ -815,7 +815,7 @@ namespace pm {
                             x = pmmath::acos(x);
                         for(std::size_t j{0u}; j < bIdx[i].size(); ++j) {
                             if(fbands[i].part[j]*(1.0-1e-12) <= x && 
-                            x <= fbands[i].part[j+1u]*(1.0+1e-12)) {
+                                        x <= fbands[i].part[j+1u]*(1.0+1e-12)) {
                                 if(a[2u*bIdx[i][j]] != a[2u*bIdx[i][j]+1u]) {
                                     return ((x-fbands[i].part[j]) * a[2u*bIdx[i][j]+1u] -
                                             (x-fbands[i].part[j+1u]) * a[2u*bIdx[i][j]]) /
@@ -858,7 +858,7 @@ namespace pm {
                             nx = pmmath::acos(x);
                         for(std::size_t j{0u}; j < bIdx[i].size(); ++j) {
                             if(fbands[i].part[j]*(1.0-1e-12) <= nx && 
-                            nx <= fbands[i].part[j+1u]*(1.0+1e-12)) {
+                                        nx <= fbands[i].part[j+1u]*(1.0+1e-12)) {
                                 if(a[2u*bIdx[i][j]] != a[2u*bIdx[i][j]+1u]) {
                                     return ((nx-fbands[i].part[j]) * a[2u*bIdx[i][j]+1u] -
                                             (nx-fbands[i].part[j+1u]) * a[2u*bIdx[i][j]]) /

--- a/src/pm.cpp
+++ b/src/pm.cpp
@@ -873,7 +873,7 @@ namespace pm {
                 }
             }
 
-            std::vector<band_t<T>> cbands = bandconv(fbands);
+            std::vector<band_t<T>> cbands;
             std::function<T(T)> wf = [&cbands](T x) -> T {
                 for(std::size_t i{0u}; i < cbands.size(); ++i)
                     if(cbands[i].start <= x && x <= cbands[i].stop)
@@ -924,6 +924,7 @@ namespace pm {
                         }
                         output = exchange(x, cbands, eps, nmax, prec);
                     } else { // AFP-based strategy
+                        cbands = bandconv(fbands);
                         std::vector<T> mesh = wam(cbands, sdegs[0]);
                         MatrixXd<T> A = chebvand(sdegs[0]+1u, mesh, wf);
                         x = afp(A, mesh);
@@ -944,7 +945,8 @@ namespace pm {
                         output = exchange(x, cbands, eps, nmax, prec);
                     }
                 } break;
-                default: { // AFP-based initialization
+                case init_t::AFP: { // AFP-based initialization
+                    cbands = bandconv(fbands);
                     std::vector<T> mesh = wam(cbands, deg);
                     MatrixXd<T> A = chebvand(deg+1u, mesh, wf);
                     std::vector<T> x = afp(A, mesh);
@@ -956,7 +958,9 @@ namespace pm {
                     }
                     countBand(cbands, x);
                     output = exchange(x, cbands, eps, nmax, prec);
-                }
+                } break;
+                default:
+                    throw std::runtime_error("Unknown strategy!");
             }
 
             if (output.h.size() != deg + 1u) {
@@ -1218,7 +1222,7 @@ namespace pm {
                 }
             }
 
-            std::vector<band_t<T>> cbands = bandconv(fbands);
+            std::vector<band_t<T>> cbands;
             std::function<T(T)> wf = [&cbands](T x) -> T {
                 for(std::size_t i{0u}; i < cbands.size(); ++i)
                     if(cbands[i].start <= x && x <= cbands[i].stop)
@@ -1253,6 +1257,7 @@ namespace pm {
                             cbands = bandconv(fbands);
                         } else {
                             // use AFP strategy for very small degrees (wrt nb of bands)
+                            cbands = bandconv(fbands);
                             std::vector<T> mesh = wam(cbands, sdegs[0]);
                             MatrixXd<T> A = chebvand(sdegs[0]+1u, mesh, wf);
                             x = afp(A, mesh);
@@ -1266,6 +1271,7 @@ namespace pm {
                         }
                         output = exchange(x, cbands, eps, nmax);
                     } else { // AFP-based strategy
+                        cbands = bandconv(fbands);
                         std::vector<T> mesh = wam(cbands, sdegs[0]);
                         MatrixXd<T> A = chebvand(sdegs[0]+1u, mesh, wf);
                         x = afp(A, mesh);
@@ -1285,7 +1291,8 @@ namespace pm {
                         output = exchange(x, cbands, eps, nmax, prec);
                     }
                 } break;
-                default: { // AFP-based initialization
+                case init_t::AFP: { // AFP-based initialization
+                    cbands = bandconv(fbands);
                     std::vector<T> mesh = wam(cbands, deg);
                     MatrixXd<T> A = chebvand(deg+1u, mesh, wf);
                     std::vector<T> x = afp(A, mesh);
@@ -1297,7 +1304,9 @@ namespace pm {
                     }
                     countBand(cbands, x);
                     output = exchange(x, cbands, eps, nmax, prec);
-                }
+                } break;
+                default:
+                    throw std::runtime_error("Unknown strategy!");
             }
 
             if (output.h.size() != deg + 1u) {

--- a/src/pm.cpp
+++ b/src/pm.cpp
@@ -37,7 +37,7 @@ namespace pm {
 
     template<typename T>
     MatrixXd<T> chebvand(std::size_t degree,
-            std::vector<T>& meshPoints,
+            std::vector<T> const &meshPoints,
             std::function<T(T)>& weightFunction)
     {
         MatrixXd<T> A(degree + 1u, meshPoints.size());
@@ -57,7 +57,7 @@ namespace pm {
 
     // approximate Fekete points
     template<typename T>
-    std::vector<T> afp(MatrixXd<T>& A, std::vector<T>& mesh)
+    std::vector<T> afp(MatrixXd<T> const &A, std::vector<T>& mesh)
     {
         std::vector<T> points;
         VectorXd<T> b = VectorXd<T>::Ones(A.rows());
@@ -90,7 +90,7 @@ namespace pm {
     }
 
     template<typename T>
-    std::vector<T> wam(std::vector<band_t<T>>& cb, std::size_t deg)
+    std::vector<T> wam(std::vector<band_t<T>> const &cb, std::size_t deg)
     {
         std::vector<T> wam;
         std::vector<T> cp = equipts<T>(deg + 2u);

--- a/src/pm.cpp
+++ b/src/pm.cpp
@@ -889,25 +889,9 @@ namespace pm {
             switch(strategy) {
                 case init_t::UNIFORM:
                 {
-                    std::vector<T> x;
-                    if (fbands.size() <= (deg + 2u) / 4) {
-                        std::vector<T> omega = uniform(fbands, deg + 2u);
-                        x = cos(omega);
-                        cbands = bandconv(fbands);
-                    } else {
-                        // use AFP strategy for very small degrees (wrt nb of bands)
-                        std::vector<T> mesh = wam(cbands, deg);
-                        MatrixXd<T> A = chebvand(deg+1u, mesh, wf);
-                        x = afp(A, mesh);
-                        if(x.size() != deg + 2u) {
-                            output.status = status_t::STATUS_AFP_INVALID;
-                            throw std::runtime_error("ERROR: AFP strategy "
-                                    "failed to produce a valid starting "
-                                    "reference.\nPOSSIBLE CAUSE: badly "
-                                    "conditioned Chebyshev Vandermonde matrix");
-                        }
-                        countBand(cbands, x);
-                    }
+                    std::vector<T> omega = uniform(fbands, deg + 2u);
+                    std::vector<T> x = cos(omega);
+                    cbands = bandconv(fbands);
                     output = exchange(x, cbands, eps, nmax, prec);
                 } break;
                 case init_t::SCALING:
@@ -1249,24 +1233,9 @@ namespace pm {
             switch(strategy) {
                 case init_t::UNIFORM:
                 {
-                    std::vector<T> x;
-                    if (fbands.size() <= (deg + 2u) / 4) {
-                        std::vector<T> omega = uniform(fbands, deg + 2u);
-                        x = cos(omega);
-                        cbands = bandconv(fbands);
-                    } else {
-                        // use AFP strategy for very small degrees (wrt nb of bands)
-                        std::vector<T> mesh = wam(cbands, deg);
-                        MatrixXd<T> A = chebvand(deg+1u, mesh, wf);
-                        x = afp(A, mesh);
-                        if(x.size() != deg + 2u) {
-                            output.status = status_t::STATUS_AFP_INVALID;
-                            throw std::runtime_error(
-                                    "ERROR: AFP strategy failed to produce a valid starting reference\n"
-                                    "POSSIBLE CAUSE: badly conditioned Chebyshev Vandermonde matrix");
-                        }
-                        countBand(cbands, x);
-                    }
+                    std::vector<T> omega = uniform(fbands, deg + 2u);
+                    std::vector<T> x = cos(omega);
+                    cbands = bandconv(fbands);
                     output = exchange(x, cbands, eps, nmax, prec);
                 } break;
                 case init_t::SCALING:

--- a/src/pm.cpp
+++ b/src/pm.cpp
@@ -758,7 +758,6 @@ namespace pm {
 
         try {
             parseSpecification(output.status, f, a, w);
-            std::vector<T> h;
             std::vector<band_t<T>> fbands;
             std::vector<std::vector<std::size_t>> bIdx;
 
@@ -791,7 +790,6 @@ namespace pm {
                     ++n;
                 }
             }
-            std::size_t deg = n / 2;
             if(n % 2 == 0) {            // type I filter
                 for(std::size_t i{0u}; i < fbands.size(); ++i) {
                     fbands[i].part.push_back(T(pmmath::const_pi<T>() * f[2u*bIdx[i][0u]]));
@@ -884,6 +882,7 @@ namespace pm {
                 return 1.0;
             };
 
+            std::size_t deg = n / 2;
             if(fbands.size() > (deg + 2u) / 4)
                 strategy = init_t::AFP;
 
@@ -976,12 +975,12 @@ namespace pm {
                 }
             }
 
-            h.resize(n+1u);
             if (output.h.size() != deg + 1u) {
                 output.status = status_t::STATUS_COEFFICIENT_SET_INVALID;
                 throw std::runtime_error("ERROR: final filter coefficient set is incomplete");
             }
 
+            std::vector<T> h(n + 1u);
             if(n % 2 == 0) {
                 h[deg] = output.h[0];
                 for(std::size_t i{0u}; i < deg; ++i)
@@ -1061,7 +1060,6 @@ namespace pm {
 
         try {
             parseSpecification(output.status, f, a, w);
-            std::vector<T> h;
             std::vector<band_t<T>> fbands(w.size());
             std::vector<T> fn{f};
             std::size_t deg = n / 2u;
@@ -1333,12 +1331,12 @@ namespace pm {
                 }
             }
 
-            h.resize(n + 1u);
             if (output.h.size() != deg + 1u) {
                 output.status = status_t::STATUS_COEFFICIENT_SET_INVALID;
                 throw std::runtime_error("ERROR: final filter coefficient set is incomplete");
             }
 
+            std::vector<T> h(n + 1u);
             if(n % 2 == 0)
             {
                 h[deg + 1u] = 0;

--- a/src/pm.cpp
+++ b/src/pm.cpp
@@ -19,8 +19,6 @@
 #include "firpm/barycentric.h"
 #include "firpm/pmmath.h"
 #include <set>
-#include <fstream>
-#include <sstream>
 #include <algorithm>
 #include <stdexcept>
 
@@ -468,12 +466,11 @@ namespace pm {
         if(alternatingExtrema.size() < x.size())
         {
             status = status_t::STATUS_EXCHANGE_FAILURE;
-            std::stringstream message;
-            message << "ERROR: The exchange algorithm did not converge\n"
-                << "TRIGGER: Not enough alternating extrema\n"
-                << "POSSIBLE CAUSE: nmax too small\n";
             convergenceOrder = 2.0;
-            throw std::runtime_error(message.str());
+            throw std::runtime_error(
+                    "ERROR: The exchange algorithm did not converge\n"
+                    "TRIGGER: Not enough alternating extrema\n"
+                    "POSSIBLE CAUSE: nmax too small");
         }
         else if (alternatingExtrema.size() > x.size())
         {
@@ -557,12 +554,11 @@ namespace pm {
         }
         if (alternatingExtrema.size() < x.size()) {
             status = status_t::STATUS_EXCHANGE_FAILURE;
-            std::stringstream message;
-            message << "ERROR: The exchange algorithm did not converge\n"
-                << "TRIGGER: Not enough alternating extrema\n"
-                << "POSSIBLE CAUSE: nmax too small\n";
             convergenceOrder = 2.0;
-            throw std::runtime_error(message.str());
+            throw std::runtime_error(
+                    "ERROR: The exchange algorithm did not converge\n"
+                    "TRIGGER: Not enough alternating extrema\n"
+                    "POSSIBLE CAUSE: nmax too small");
         }
 
         for (auto& it : alternatingExtrema)
@@ -675,12 +671,11 @@ namespace pm {
             fv[i] = approx(finalChebyNodes[i], output.x, finalC, finalAlpha);
             if (!pmmath::isfinite(fv[i])) {
                 output.status = status_t::STATUS_COEFFICIENT_SET_INVALID;
-                std::stringstream message;
-                message << "ERROR: Invalid frequency response generated.\n"
-                    << "TRIGGER: infinite/NaN values in the final frequency response.\n"
-                    << "POSSIBLE CAUSE: too small numerical precision and/or a too "
-                    << "small value for nmax.";
-                throw std::runtime_error(message.str());
+                throw std::runtime_error(
+                        "ERROR: Invalid frequency response generated.\n"
+                        "TRIGGER: infinite/NaN values in the final frequency response.\n"
+                        "POSSIBLE CAUSE: too small numerical precision and/or a too "
+                        "small value for nmax.");
             }
         }
 
@@ -707,10 +702,9 @@ namespace pm {
 
         if(f.size() != w.size() * 2u) {
             status = status_t::STATUS_WEIGHT_VECTOR_MISMATCH;
-            std::stringstream message;
-            message << "ERROR: Weight vector size does not match the"
-                << " the number of frequency bands in the specification";
-            throw std::domain_error(message.str());
+            throw std::domain_error(
+                   "ERROR: Weight vector size does not match the "
+                   "number of frequency bands in the specification");
         }
 
         for(std::size_t i{0u}; i < f.size() - 1u; ++i) {
@@ -908,11 +902,10 @@ namespace pm {
                         x = afp(A, mesh);
                         if(x.size() != deg + 2u) {
                             output.status = status_t::STATUS_AFP_INVALID;
-                            std::stringstream message;
-                            message << "ERROR: AFP strategy failed to produce a valid starting "
-                                << "reference\n"
-                                << "POSSIBLE CAUSE: badly conditioned Chebyshev Vandermonde matrix";
-                            throw std::runtime_error(message.str());
+                            throw std::runtime_error("ERROR: AFP strategy "
+                                    "failed to produce a valid starting "
+                                    "reference.\nPOSSIBLE CAUSE: badly "
+                                    "conditioned Chebyshev Vandermonde matrix");
                         }
                         countBand(cbands, x);
                     }
@@ -938,12 +931,11 @@ namespace pm {
                             x = afp(A, mesh);
                             if(x.size() != sdegs[0] + 2u) {
                                 output.status = status_t::STATUS_AFP_INVALID;
-                                std::stringstream message;
-                                message << "ERROR: AFP strategy failed to produce a valid "
-                                    << "starting reference\n"
-                                    << "POSSIBLE CAUSE: badly conditioned Chebyshev "
-                                    << "Vandermonde matrix";
-                                throw std::runtime_error(message.str());
+                                throw std::runtime_error(
+                                        "ERROR: AFP strategy failed to"
+                                        "produce a valid starting reference\n"
+                                        "POSSIBLE CAUSE: badly conditioned Chebyshev "
+                                        "Vandermonde matrix");
                             }
                             countBand(cbands, x);
                         }
@@ -954,11 +946,10 @@ namespace pm {
                         x = afp(A, mesh);
                         if(x.size() != sdegs[0] + 2u) {
                             output.status = status_t::STATUS_AFP_INVALID;
-                            std::stringstream message;
-                            message << "ERROR: AFP strategy failed to produce a valid "
-                                << "starting reference\n"
-                                << "POSSIBLE CAUSE: badly conditioned Chebyshev Vandermonde matrix";
-                            throw std::runtime_error(message.str());
+                            throw std::runtime_error(
+                                    "ERROR: AFP strategy failed to "
+                                    "produce a valid starting reference\n"
+                                    "POSSIBLE CAUSE: badly conditioned Chebyshev Vandermonde matrix");
                         }
                         countBand(cbands, x);
                         output = exchange(x, cbands, eps, nmax, prec);
@@ -976,10 +967,9 @@ namespace pm {
                     std::vector<T> x = afp(A, mesh);
                     if(x.size() != deg + 2u) {
                         output.status = status_t::STATUS_AFP_INVALID;
-                        std::stringstream message;
-                        message << "ERROR: AFP strategy failed to produce a valid starting reference\n"
-                            << "POSSIBLE CAUSE: badly conditioned Chebyshev Vandermonde matrix";
-                        throw std::runtime_error(message.str());
+                        throw std::runtime_error(
+                                "ERROR: AFP strategy failed to produce a valid starting reference\n"
+                                "POSSIBLE CAUSE: badly conditioned Chebyshev Vandermonde matrix");
                     }
                     countBand(cbands, x);
                     output = exchange(x, cbands, eps, nmax, prec);
@@ -1273,11 +1263,9 @@ namespace pm {
                         x = afp(A, mesh);
                         if(x.size() != deg + 2u) {
                             output.status = status_t::STATUS_AFP_INVALID;
-                            std::stringstream message;
-                            message << "ERROR: AFP strategy failed to produce a valid starting "
-                                << "reference\n"
-                                << "POSSIBLE CAUSE: badly conditioned Chebyshev Vandermonde matrix";
-                            throw std::runtime_error(message.str());
+                            throw std::runtime_error(
+                                    "ERROR: AFP strategy failed to produce a valid starting reference\n"
+                                    "POSSIBLE CAUSE: badly conditioned Chebyshev Vandermonde matrix");
                         }
                         countBand(cbands, x);
                     }
@@ -1303,10 +1291,9 @@ namespace pm {
                             x = afp(A, mesh);
                             if(x.size() != sdegs[0] + 2u) {
                                 output.status = status_t::STATUS_AFP_INVALID;
-                                std::stringstream message;
-                                message << "ERROR: AFP strategy failed to produce a valid starting "        << "reference\n"
-                                    << "POSSIBLE CAUSE: badly conditioned Chebyshev Vandermonde matrix";
-                                throw std::runtime_error(message.str());
+                                throw std::runtime_error(
+                                        "ERROR: AFP strategy failed to produce a valid starting reference\n"
+                                        "POSSIBLE CAUSE: badly conditioned Chebyshev Vandermonde matrix");
                             }
                             countBand(cbands, x);
                         }
@@ -1317,10 +1304,9 @@ namespace pm {
                         x = afp(A, mesh);
                         if(x.size() != sdegs[0] + 2u) {
                             output.status = status_t::STATUS_AFP_INVALID;
-                            std::stringstream message;
-                            message << "ERROR: AFP strategy failed to produce a valid starting "            << "reference\n"
-                                << "POSSIBLE CAUSE: badly conditioned Chebyshev Vandermonde matrix";
-                            throw std::runtime_error(message.str());
+                            throw std::runtime_error(
+                                    "ERROR: AFP strategy failed to produce a valid starting reference\n"
+                                    "POSSIBLE CAUSE: badly conditioned Chebyshev Vandermonde matrix");
                         }
                         countBand(cbands, x);
                         output = exchange(x, cbands, eps, nmax);
@@ -1338,10 +1324,9 @@ namespace pm {
                     std::vector<T> x = afp(A, mesh);
                     if(x.size() != deg + 2u) {
                         output.status = status_t::STATUS_AFP_INVALID;
-                        std::stringstream message;
-                        message << "ERROR: AFP strategy failed to produce a valid starting reference\n"
-                            << "POSSIBLE CAUSE: badly conditioned Chebyshev Vandermonde matrix";
-                        throw std::runtime_error(message.str());
+                        throw std::runtime_error(
+                                "ERROR: AFP strategy failed to produce a valid starting reference\n"
+                                "POSSIBLE CAUSE: badly conditioned Chebyshev Vandermonde matrix");
                     }
                     countBand(cbands, x);
                     output = exchange(x, cbands, eps, nmax, prec);

--- a/src/pm.cpp
+++ b/src/pm.cpp
@@ -873,7 +873,7 @@ namespace pm {
                 }
             }
 
-            std::vector<band_t<T>> cbands = bandconv(fbands, convdir_t::FROMFREQ);
+            std::vector<band_t<T>> cbands = bandconv(fbands);
             std::function<T(T)> wf = [&cbands](T x) -> T {
                 for(std::size_t i{0u}; i < cbands.size(); ++i)
                     if(cbands[i].start <= x && x <= cbands[i].stop)
@@ -893,7 +893,7 @@ namespace pm {
                     if (fbands.size() <= (deg + 2u) / 4) {
                         std::vector<T> omega = uniform(fbands, deg + 2u);
                         x = cos(omega);
-                        cbands = bandconv(fbands, convdir_t::FROMFREQ);
+                        cbands = bandconv(fbands);
                     } else {
                         // use AFP strategy for very small degrees (wrt nb of bands)
                         std::vector<T> mesh = wam(cbands, deg);
@@ -922,7 +922,7 @@ namespace pm {
                         if (fbands.size() <= (sdegs[0] + 2u) / 4) {
                             std::vector<T> omega = uniform(fbands, sdegs[0]+2u);
                             x = cos(omega);
-                            cbands = bandconv(fbands, convdir_t::FROMFREQ);
+                            cbands = bandconv(fbands);
                         } else {
                             // use AFP strategy for very small degrees (wrt nb of bands)
                             std::vector<T> mesh = wam(cbands, sdegs[0]);
@@ -1234,7 +1234,7 @@ namespace pm {
                 }
             }
 
-            std::vector<band_t<T>> cbands = bandconv(fbands, convdir_t::FROMFREQ);
+            std::vector<band_t<T>> cbands = bandconv(fbands);
             std::function<T(T)> wf = [&cbands](T x) -> T {
                 for(std::size_t i{0u}; i < cbands.size(); ++i)
                     if(cbands[i].start <= x && x <= cbands[i].stop)
@@ -1253,7 +1253,7 @@ namespace pm {
                     if (fbands.size() <= (deg + 2u) / 4) {
                         std::vector<T> omega = uniform(fbands, deg + 2u);
                         x = cos(omega);
-                        cbands = bandconv(fbands, convdir_t::FROMFREQ);
+                        cbands = bandconv(fbands);
                     } else {
                         // use AFP strategy for very small degrees (wrt nb of bands)
                         std::vector<T> mesh = wam(cbands, deg);
@@ -1281,7 +1281,7 @@ namespace pm {
                         if (fbands.size() <= (sdegs[0] + 2u) / 4) {
                             std::vector<T> omega = uniform(fbands, sdegs[0]+2u);
                             x = cos(omega);
-                            cbands = bandconv(fbands, convdir_t::FROMFREQ);
+                            cbands = bandconv(fbands);
                         } else {
                             // use AFP strategy for very small degrees (wrt nb of bands)
                             std::vector<T> mesh = wam(cbands, sdegs[0]);

--- a/test/scaling_tests.cpp
+++ b/test/scaling_tests.cpp
@@ -58,16 +58,12 @@ TYPED_TEST(firpm_scaling_test, lowpass50a)
     freqBands[1].space = pm::space_t::FREQ;
     freqBands[1].amplitude = [](pm::space_t, T) -> T { return 0; };
 
-
-
     auto start = std::chrono::steady_clock::now();
 
     std::size_t degree = 50;
-    std::vector<T> a;
-    std::vector<pm::band_t<T>> chebyBands;
     std::vector<T> omega = pm::uniform(freqBands, degree + 2u);
     std::vector<T> x = pm::cos(omega);
-    pm::bandconv(chebyBands, freqBands, pm::convdir_t::FROMFREQ);
+    std::vector<pm::band_t<T>> chebyBands = pm::bandconv(freqBands, pm::convdir_t::FROMFREQ);
 
     auto output = pm::exchange(x, chebyBands);
     ASSERT_LT(output.q, 1e-2);

--- a/test/scaling_tests.cpp
+++ b/test/scaling_tests.cpp
@@ -65,10 +65,8 @@ TYPED_TEST(firpm_scaling_test, lowpass50a)
     std::size_t degree = 50;
     std::vector<T> a;
     std::vector<pm::band_t<T>> chebyBands;
-    std::vector<T> omega(degree + 2u);
-    std::vector<T> x(degree + 2u);
-    pm::uniform(omega, freqBands, degree + 2u);
-    pm::cos(x, omega);
+    std::vector<T> omega = pm::uniform(freqBands, degree + 2u);
+    std::vector<T> x = pm::cos(omega);
     pm::bandconv(chebyBands, freqBands, pm::convdir_t::FROMFREQ);
 
     auto output = pm::exchange(x, chebyBands);

--- a/test/scaling_tests.cpp
+++ b/test/scaling_tests.cpp
@@ -63,7 +63,7 @@ TYPED_TEST(firpm_scaling_test, lowpass50a)
     std::size_t degree = 50;
     std::vector<T> omega = pm::uniform(freqBands, degree + 2u);
     std::vector<T> x = pm::cos(omega);
-    std::vector<pm::band_t<T>> chebyBands = pm::bandconv(freqBands, pm::convdir_t::FROMFREQ);
+    std::vector<pm::band_t<T>> chebyBands = pm::bandconv(freqBands);
 
     auto output = pm::exchange(x, chebyBands);
     ASSERT_LT(output.q, 1e-2);


### PR DESCRIPTION
This simplifies call sites in pm.cpp, and avoids a number of assumptions
about arrays being allocated with the correct sizes.

I am not a C++ guru, but I believe this change will not produce less
performant code using c++17 or later compilers (which guarantee copy
elision under these circumstances.)