### PR TITLE
Initial support for compiling Python bindings using pybind11.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(Eigen3 3.3 REQUIRED)
 find_package(GMP 6.0.0)
 find_package(MPFR 4.0.0)
 find_package(Doxygen)
+find_package(pybind11)
 
 if( MPFR_FOUND AND GMP_FOUND)
     add_definitions(-DHAVE_MPFR)
@@ -41,6 +42,15 @@ endif( MPFR_FOUND AND GMP_FOUND )
 add_subdirectory(${PROJECT_SOURCE_DIR}/src)
 if(DOXYGEN_FOUND)
     add_subdirectory(${PROJECT_SOURCE_DIR}/doc)
+endif()
+
+#-----------------------------------------------------------------------
+# Python bindings
+#-----------------------------------------------------------------------
+
+if( pybind11_FOUND )
+	pybind11_add_module(pyfirpm py/bindings.cpp)
+	target_link_libraries(pyfirpm PRIVATE firpm)
 endif()
 
 #-----------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ find_package(GMP 6.0.0)
 find_package(MPFR 4.0.0)
 find_package(Doxygen)
 find_package(pybind11)
+find_package(Python3)
 
 if( MPFR_FOUND AND GMP_FOUND)
     add_definitions(-DHAVE_MPFR)
@@ -137,3 +138,7 @@ endif()
 
 add_test(ScalingTests ${PROJECT_TEST_SCALING})
 add_test(ExtensiveTests ${PROJECT_TEST_EXTENSIVE})
+
+if( pybind11_FOUND AND Python3_FOUND )
+	add_test(NAME PythonTests COMMAND ${Python3_EXECUTABLE} -m pytest test/firpm_tests.py)
+endif()

--- a/py/bindings.cpp
+++ b/py/bindings.cpp
@@ -1,0 +1,39 @@
+#include "firpm.h"
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+using pm::firpm;
+using namespace pybind11::literals;
+
+PYBIND11_MODULE(pyfirpm, m){
+
+    py::enum_<pm::init_t>(m, "Strategy")
+        .value("UNIFORM", pm::init_t::UNIFORM)
+        .value("SCALING", pm::init_t::SCALING)
+        .value("AFP", pm::init_t::AFP)
+        .export_values();
+
+    m.def("firpm", [](std::size_t n,
+              std::vector<double> f, std::vector<double> a, std::vector<double> w,
+              double eps,
+              std::size_t nmax,
+              pm::init_t strategy,
+              std::size_t depth,
+              pm::init_t rstrategy,
+              unsigned long prec) {
+            return firpm<double>(n, f, a, w, eps, nmax, strategy, depth, rstrategy, prec).h;
+        },
+        "n"_a,
+        "f"_a,
+        "a"_a,
+        "w"_a,
+        "eps"_a=0.01,
+        "nmax"_a=4,
+        "strategy"_a=pm::init_t::UNIFORM,
+        "depth"_a=0u,
+        "rstrategy"_a=pm::init_t::UNIFORM,
+        "prec"_a=165ul,
+        "Parks-McClellan routine for implementing type I and II FIR filters.");
+}

--- a/test/firpm_tests.py
+++ b/test/firpm_tests.py
@@ -1,0 +1,54 @@
+import pytest
+import pyfirpm
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+@pytest.mark.parametrize("n, fpass, fstop, ripple, attenuation", [
+    # Specification 4
+    (1000, 0.8, 0.81, 0.1, -90),
+    (2001, 0.8, 0.81, 0.1, -90),
+
+    # Specification 5
+    (2002, 0.1, 0.105, 0.1, -90),
+])
+def test_lpf_spectrum(request, n, fpass, fstop, ripple, attenuation):
+    success = True
+
+    NFFT=1024
+
+    h = pyfirpm.firpm(n, [0.0, fpass, fstop, 1.0], [1.0, 1.0, 0.0, 0.0], [1.0, 10.0])
+
+    # Form spectrum in dB
+    hdb = 20 * np.log10(np.abs(np.fft.fft(h)))
+    f = np.linspace(0, 2, len(hdb))
+
+    # Plot spectrum in dB
+    fig, ax = plt.subplots(figsize=(6, 3))
+    ax.plot(f, hdb)
+
+    # Verify passband ripple
+    passband_exceptions = np.argwhere((f < fpass) * (abs(hdb) > ripple) * (f < 1))
+    if len(passband_exceptions):
+        ax.plot(f[passband_exceptions], hdb[passband_exceptions],
+                'ro', fillstyle='none')
+        success = False
+
+    # Verify stopband attenuation
+    amp_stopband = np.argwhere((f > fstop) * (hdb > attenuation) * (f < 1))
+    if len(amp_stopband):
+        ax.plot(f[amp_stopband], hdb[amp_stopband],
+                'ro', fillstyle='none')
+        success = False
+
+    # Produce plot
+    ax.set_xlim([0, 1])
+    ax.set_xlabel('Frequency')
+    ax.set_ylabel('Amplitude (dB)')
+    ax.set_title(request.node.name)
+    ax.grid(True)
+    fig.savefig(f'{request.node.name}.pdf')
+
+    # Raise deferred exception if we failed
+    assert success


### PR DESCRIPTION
This is incomplete in a few ways:

- Only a single binding for the simplest firpm<double>() call is present.
- No error pathways are present.
- It likely fails to build if pybind11 is not present (this should be
  allowed)
- It does not include any Python code, including setup.py boilerplate
- There is no test code yet

However, it is already probably useful for extending C++ test cases with
some "higher level" tests in Python that use the (excellent) numpy/scipy
packages to generate frequency-domain performance metrics.